### PR TITLE
ALPHA-46 Implemented pushing docker image to ECR

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -49,19 +49,20 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Build Docker image
-        run: docker build -t django-app:latest .
-
-      # Pushing Docker Image to Amazon ECR
-      - name: Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: docker/build-push-action@v5
         with:
-          region: us-east-1
+          context: .
+          push: false
+          tags: ubl-despatch-generator:latest
+          outputs: type=docker,dest=/tmp/ubl-despatch-image.tar
+      
+      - name: Upload Docker image as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ubl-despatch-image
+          path: /tmp/ubl-despatch-image.tar
+          retention-days: 1
 
-      - name: Tag Docker image
-        run: docker tag django-app:latest ${{ vars.ECR_REPO }}
-          
-      - name: Push Docker image to ECR
-        run: docker push ${{ vars.ECR_REPO }}
 
   test:
     runs-on: ubuntu-latest
@@ -103,6 +104,47 @@ jobs:
     steps:
       - name: Placeholder for integration tests
         run: echo "Integration tests will be implemented later."
+
+  # ECR deployment job
+  deploy-to-ecr:
+    runs-on: ubuntu-latest
+    needs: [lint, build, test, integration-tests]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Download Docker image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ubl-despatch-image
+          path: /tmp
+      
+      - name: Load Docker image
+        run: docker load --input /tmp/ubl-despatch-image.tar
+      
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+      
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+      
+      - name: Tag and push image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker tag ubl-despatch-generator:latest $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker tag ubl-despatch-generator:latest $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          echo "Successfully pushed image to ECR: $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 
   notify:
     name: Notify on Failure


### PR DESCRIPTION
Continuous deployment for Django app to AWS ECS Fargate using an ECR Docker image.

Step 1: pushing the Docker Image to ECR